### PR TITLE
feat: check if goal reached for yaw before

### DIFF
--- a/scripts/environments/RotationEnvironment.py
+++ b/scripts/environments/RotationEnvironment.py
@@ -116,7 +116,16 @@ class RotationEnvironment(Environment):
         yaw_before_rounded = round(yaw_before)
         yaw_after_rounded = round(yaw_after)
 
-        goal_difference = self.rotation_min_difference(target_goal, yaw_after_rounded)
+        goal_difference_before = self.rotation_min_difference(target_goal, yaw_before_rounded)
+        goal_difference_after = self.rotation_min_difference(target_goal, yaw_after_rounded)
+
+        # Current yaw_before might not equal yaw_after in prev step, hence need to check before as well to see if it has reached the goal already
+        if (goal_difference_before <= precision_tolerance):
+            logging.info("----------Reached the Goal!----------")
+            reward += 10
+            done = True
+            return reward, done
+
         delta_changes   = self.rotation_min_difference(target_goal, yaw_before_rounded) - self.rotation_min_difference(target_goal, yaw_after_rounded)
         
         logging.info(f"Yaw = {yaw_after_rounded}")
@@ -133,7 +142,7 @@ class RotationEnvironment(Environment):
                 reward = raw_reward
 
         precision_tolerance = 10
-        if goal_difference <= precision_tolerance:
+        if goal_difference_after <= precision_tolerance:
             logging.info("----------Reached the Goal!----------")
             reward += 10
             done = True

--- a/scripts/environments/RotationEnvironment.py
+++ b/scripts/environments/RotationEnvironment.py
@@ -122,6 +122,7 @@ class RotationEnvironment(Environment):
         # Current yaw_before might not equal yaw_after in prev step, hence need to check before as well to see if it has reached the goal already
         if (goal_difference_before <= precision_tolerance):
             logging.info("----------Reached the Goal!----------")
+            logging.info("Warning: Yaw before in current step not equal to Yaw after in prev step")
             reward += 10
             done = True
             return reward, done

--- a/scripts/environments/RotationEnvironment.py
+++ b/scripts/environments/RotationEnvironment.py
@@ -102,6 +102,7 @@ class RotationEnvironment(Environment):
     
     # overriding method 
     def reward_function(self, target_goal, yaw_before, yaw_after):
+        precision_tolerance = 10
 
         if yaw_before is None: 
             logging.debug("Start Marker Pose is None")
@@ -141,8 +142,7 @@ class RotationEnvironment(Environment):
                 reward = REWARD_CONSTANTS.MIN_REWARD.value
             else:
                 reward = raw_reward
-
-        precision_tolerance = 10
+        
         if goal_difference_after <= precision_tolerance:
             logging.info("----------Reached the Goal!----------")
             reward += 10


### PR DESCRIPTION
During training, a division by 0 error was encountered in the reward function.

Occurred in this function: `raw_reward = delta_changes/self.rotation_min_difference(target_goal, yaw_before_rounded)`

It is likely `yaw_before` in current step is not equal to `yaw_after` in prev step, hence we need an additional check for yaw_before to see if goal is already reached.